### PR TITLE
Link against prototyped functions

### DIFF
--- a/src/air.cpp
+++ b/src/air.cpp
@@ -882,7 +882,7 @@ void CreateInterferenceDOT(air_function* function, const char* functionName)
 
       case slot::slot_type::STRING_CONSTANT:
       {
-        fprintf(f, "\ts%u[label=\"\"%s\" : STRING\" color=\"%s\" fontcolor=\"%s\"];\n", i, (**slotIt)->payload.string->string, color, color);
+        fprintf(f, "\ts%u[label=\"\\\"%s\\\" : STRING\" color=\"%s\" fontcolor=\"%s\"];\n", i, (**slotIt)->payload.string->string, color, color);
       } break;
     }
 

--- a/src/air.cpp
+++ b/src/air.cpp
@@ -396,6 +396,7 @@ void GenNodeAIR<void>(air_function* function, node* n)
 
     case FUNCTION_CALL_NODE:
     {
+      printf("Function call node\n");
       for (auto* paramIt = n->payload.functionCall.params.first;
            paramIt;
            paramIt = paramIt->next)
@@ -712,6 +713,11 @@ void PrintInstruction(air_instruction* instruction)
     case I_NEGATE:
     {
 
+    } break;
+
+    case I_CALL:
+    {
+      printf("CALL %s\n", instruction->payload.function->name);
     } break;
   }
 }

--- a/src/air.hpp
+++ b/src/air.hpp
@@ -42,15 +42,24 @@ struct slot
     PARAM,            // NOTE(Isaac): `variable` field of `payload` is valid
     LOCAL,            // NOTE(Isaac): `variable` field of `payload` is valid
     INTERMEDIATE,     // NOTE(Isaac): `payload` is undefined
+
+    /*
+     * Used to store the parameters of function calls in the correct registers according to the ABI
+     * NOTE(Isaac): comes precolored
+     */
+    IN_PARAM,
+
     INT_CONSTANT,     // NOTE(Isaac): `i` field of `payload` is valid
     FLOAT_CONSTANT,   // NOTE(Isaac): `f` field of `payload` is valid
+    STRING_CONSTANT,  // NOTE(Isaac): `string` field of `payload` is valid
   } type;
 
   union
   {
-    variable_def* variable;
-    int           i;
-    float         f;
+    variable_def*     variable;
+    int               i;
+    float             f;
+    string_constant*  string;
   } payload;
 
   /*

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -324,6 +324,11 @@ void ApplyASTPass(parse_result& parse, ast_passlet pass[NUM_AST_NODES])
        functionIt;
        functionIt = functionIt->next)
   {
+    if (GetAttrib(**functionIt, function_attrib::attrib_type::PROTOTYPE))
+    {
+      continue;
+    }
+
     ApplyPassToNode((**functionIt)->ast, **functionIt, pass, parse);
   }
 }

--- a/src/codegen_x64elf.cpp
+++ b/src/codegen_x64elf.cpp
@@ -481,6 +481,11 @@ void EmitText(code_generator& generator, parse_result& result)
        functionIt;
        functionIt = functionIt->next)
   {
+    if (GetAttrib(**functionIt, function_attrib::attrib_type::PROTOTYPE))
+    {
+      continue;
+    }
+
     printf("Generating object code for function: %s\n", (**functionIt)->name);
     assert((**functionIt)->air);
     assert((**functionIt)->air->code);

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -238,6 +238,11 @@ void CompleteAST(parse_result& parse)
        functionIt;
        functionIt = functionIt->next)
   {
+    if (GetAttrib(**functionIt, function_attrib::attrib_type::PROTOTYPE))
+    {
+      continue;
+    }
+
     ResolveTypeRef(*((**functionIt)->returnType), parse);
   }
 

--- a/src/ir.cpp
+++ b/src/ir.cpp
@@ -53,6 +53,16 @@ string_constant* CreateStringConstant(parse_result* result, char* string)
   return constant;
 }
 
+variable_def* CreateVariableDef(char* name, char* typeName, node* initValue)
+{
+  variable_def* var = static_cast<variable_def*>(malloc(sizeof(variable_def)));
+  var->name = name;
+  var->type.type.name = typeName;
+  var->type.isResolved = false;
+  var->initValue = initValue;
+  var->mostRecentSlot = nullptr;
+}
+
 function_attrib* GetAttrib(function_def* function, function_attrib::attrib_type type)
 {
   for (auto* attribIt = function->attribs.first;

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -86,13 +86,15 @@ struct function_attrib
 {
   enum attrib_type
   {
-    ENTRY
+    ENTRY,
+    PROTOTYPE,
   } type;
 };
 
 struct function_def
 {
   char*                         name;
+  bool                          isPrototype;
   linked_list<variable_def*>    params;
   linked_list<variable_def*>    locals;
   type_ref*                     returnType; // NOTE(Isaac): `nullptr` when function returns nothing

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -60,6 +60,11 @@ struct string_constant
 {
   unsigned int      handle;
   char*             string;
+
+  /*
+   * NOTE(Isaac): this is set by the code generator when it's emitted into the executable. `UINT_MAX` beforehand.
+   */
+  uint64_t offset;
 };
 
 string_constant* CreateStringConstant(parse_result* result, char* string);

--- a/src/ir.hpp
+++ b/src/ir.hpp
@@ -87,6 +87,8 @@ struct variable_def
   slot*         mostRecentSlot;
 };
 
+variable_def* CreateVariableDef(char* name, char* typeName, node* initValue);
+
 struct function_attrib
 {
   enum attrib_type

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,6 +120,11 @@ int main()
        functionIt;
        functionIt = functionIt->next)
   {
+    if (GetAttrib(**functionIt, function_attrib::attrib_type::PROTOTYPE))
+    {
+      continue;
+    }
+
     GenFunctionAIR(target, **functionIt);
   }
 

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -966,7 +966,17 @@ static void Function(roo_parser& parser, linked_list<function_attrib>& attribs)
     printf("Return type: NONE\n");
   }
 
-  definition->ast = Block(parser);
+  if (GetAttrib(definition, function_attrib::attrib_type::PROTOTYPE))
+  {
+    definition->isPrototype = true;
+    definition->ast = nullptr;
+  }
+  else
+  {
+    definition->isPrototype = false;
+    definition->ast = Block(parser);
+  }
+
   printf("<-- Function\n");
 }
 
@@ -1015,6 +1025,15 @@ static attrib_type Attribute(roo_parser& parser, linked_list<program_attrib>& pr
 
     AddToLinkedList<program_attrib>(programAttribs, attrib);
     type = attrib_type::PROGRAM;
+  }
+  else if (strcmp(attribName, "Prototype") == 0)
+  {
+    function_attrib attrib;
+    attrib.type = function_attrib::attrib_type::PROTOTYPE;
+
+    AddToLinkedList<function_attrib>(functionAttribs, attrib);
+    type = attrib_type::FUNCTION;
+    NextToken(parser);
   }
   else
   {

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -625,6 +625,7 @@ prefix_parselet g_prefixMap[NUM_TOKENS];
 infix_parselet  g_infixMap[NUM_TOKENS];
 unsigned int    g_precedenceTable[NUM_TOKENS];
 
+// TODO: doesn't appear to work for multiple parameters
 static void ParameterList(roo_parser& parser, linked_list<variable_def*>& params)
 {
   ConsumeNext(parser, TOKEN_LEFT_PAREN);
@@ -638,11 +639,11 @@ static void ParameterList(roo_parser& parser, linked_list<variable_def*>& params
 
   do
   {
-    variable_def* param = static_cast<variable_def*>(malloc(sizeof(variable_def)));
-    param->name = GetTextFromToken(PeekToken(parser));
+    char* varName = GetTextFromToken(PeekToken(parser));
     ConsumeNext(parser, TOKEN_COLON);
-    param->type.type.name = GetTextFromToken(PeekToken(parser));
-    param->type.isResolved = false;
+    char* typeName = GetTextFromToken(PeekToken(parser));
+
+    variable_def* param = CreateVariableDef(varName, typeName, nullptr);
 
     printf("Param: %s of type %s\n", param->name, param->type.type.name);
     AddToLinkedList<variable_def*>(params, param);
@@ -682,36 +683,27 @@ static node* Expression(roo_parser& parser, unsigned int precedence = 0u)
   return expression;
 }
 
-static type_ref TypeRef(roo_parser& parser)
-{
-  type_ref result;
-  result.type.name = GetTextFromToken(PeekToken(parser));
-  result.isResolved = false;
-
-  NextToken(parser);
-  return result;
-}
-
 static variable_def* VariableDef(roo_parser& parser)
 {
-  variable_def* definition = static_cast<variable_def*>(malloc(sizeof(variable_def)));
-  definition->name = GetTextFromToken(PeekToken(parser));
-
+  char* name = GetTextFromToken(PeekToken(parser));
   ConsumeNext(parser, TOKEN_COLON);
-  definition->type = TypeRef(parser);
-  
-  if (Match(parser, TOKEN_EQUALS))
+  char* typeName = GetTextFromToken(PeekToken(parser));
+  node* initValue;
+
+  if (MatchNext(parser, TOKEN_EQUALS))
   {
-    Consume(parser, TOKEN_EQUALS);
-    definition->initValue = Expression(parser);
+    ConsumeNext(parser, TOKEN_EQUALS);
+    initValue = Expression(parser);
   }
   else
   {
-    definition->initValue = nullptr;
+    initValue = nullptr;
+    NextToken(parser);
   }
 
-  printf("Defined variable: %s of type: %s\n", definition->name, definition->type.type.name);
-  return definition;
+  variable_def* variable = CreateVariableDef(name, typeName, initValue);
+  printf("Defined variable: %s of type: %s\n", variable->name, variable->type.type.name);
+  return variable;
 }
 
 static node* Statement(roo_parser& parser, bool isInLoop = false);

--- a/src/pass_resolveFunctionCalls.hpp
+++ b/src/pass_resolveFunctionCalls.hpp
@@ -29,9 +29,11 @@ void InitFunctionCallsPass()
         // TODO: be cleverer here - compare mangled names or something (functions can have the same name)
         if (strcmp((**functionIt)->name, n->payload.functionCall.function.name) == 0)
         {
+          printf("Resolved function call to: %s!\n", n->payload.functionCall.function.name);
           free(n->payload.functionCall.function.name);
           n->payload.functionCall.isResolved = true;
           n->payload.functionCall.function.def = **functionIt;
+          return;
         }
       }
 

--- a/test.roo
+++ b/test.roo
@@ -3,6 +3,11 @@
 #[Prototype]
 fn Print(str : string)
 
+fn Potato(x : int) -> int
+{
+  return x + 7
+}
+
 #[Entry]
 fn Main(y : int) -> int
 {

--- a/test.roo
+++ b/test.roo
@@ -1,5 +1,8 @@
 #[Name(test)]
 
+#[Prototype]
+fn Print(str : string)
+
 #[Entry]
 fn Main(y : int) -> int
 {

--- a/test.roo
+++ b/test.roo
@@ -7,6 +7,5 @@ fn Print(str : string)
 fn Main(y : int) -> int
 {
   Print("Hello, World!\n")
-
   return 0
 }

--- a/testStuff/test.s
+++ b/testStuff/test.s
@@ -1,21 +1,18 @@
+section .rodata
+otherMessage db "Potato",0
+message db "Hello, World!",0xa,0
+
 section .text
 global _start
-
-main:
-  push rbp
-  mov rbp, rsp
-
-  mov rax, 4
-  mov rbx, 'a'
-  int 0x80
-
-  leave
-  ret
 
 _start:
   xor rbp, rbp
 
-  call main
+  mov rdi, 1
+  mov rax, 1
+  mov rsi, message
+  mov rdx, 14
+  syscall
 
   ; Issue a SYS_exit system call
   mov rax, 1


### PR DESCRIPTION
Link against a function defined elsewhere (in a Roo library or in another language) by emitting relocations to them after defining them with a `#[Prototype]` attribute in the Roo program.